### PR TITLE
Zabbix 4.0.11 API compatibility about timestamps

### DIFF
--- a/zbx.py
+++ b/zbx.py
@@ -311,12 +311,14 @@ def get_key_item(host_id, item_key_name):
 
 def get_item_last_value(item_value_type, item_searched_id, host_id):
     """Get item last value."""
+    time_now = int(time.time())
+
     response = zapi.history.get(
         history=item_value_type,
         output='extend',
         itemids=item_searched_id,
-        time_from=time.time() - 7200,
-        time_till=time.time(),
+        time_from=time_now - 7200,
+        time_till=time_now,
         hostids=host_id,
         sortfield='clock',
         sortorder='DESC',


### PR DESCRIPTION
Hi,

Since Zabbix 4.0.11, the API history.get has been reworked and is more strict. From now times must be an integer

So When I try to grab item latest value, the following traceback appears :
```
$ zbx items get "<my_item>" --host <my_host>
Traceback (most recent call last):
  File "/usr/bin/zbx", line 9, in <module>
    load_entry_point('zbx==3.0.0', 'console_scripts', 'zbx')()
...
    raise ZabbixAPIException(msg, response_json['error']['code'])
pyzabbix.ZabbixAPIException: (u'Error -32602: Invalid params., Invalid parameter "/time_from": an integer is expected.', -32602
```

FYI, here is the Zabbix commit diff, see at line 95 .
https://github.com/zabbix/zabbix/commit/4961ad9763df1e9df582ee2d24bf4b1e7f1387c0#diff-94e6a76b72dd644f8a95acd61226b595

Regards
